### PR TITLE
Allow characters to be mapped to an empty string

### DIFF
--- a/jquery.slugit.js
+++ b/jquery.slugit.js
@@ -44,7 +44,7 @@ jQuery.fn.slugIt = function(options) {
 
         var slug = new String();
         for (var i = 0; i < text.length; i++) {
-            if ( chars[text.charAt(i)] ) { slug += chars[text.charAt(i)] }
+            if (typeof chars[text.charAt(i)] !== 'undefined' ) { slug += chars[text.charAt(i)] }
             else                         { slug += text.charAt(i) }
         }
 


### PR DESCRIPTION
Currently, you can't do 

.slugIt({map: {'7', ''}});
